### PR TITLE
Add MIT license to NuGet file.

### DIFF
--- a/src/DotNetWindowsRegistry/DotNetWindowsRegistry.csproj
+++ b/src/DotNetWindowsRegistry/DotNetWindowsRegistry.csproj
@@ -6,6 +6,7 @@
     <!-- The following properies are used to manage how the project is packaged. -->
     <PackageId>DotNetWindowsRegsitry</PackageId>
     <Copyright>Copyright (c) Dave Kerr 2020</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/dwmkerr/dotnet-windows-registry</PackageProjectUrl>
     <RepositoryUrl>https://github.com/dwmkerr/dotnet-windows-registry</RepositoryUrl>
     <Version>0.1.0-alpha1</Version>


### PR DESCRIPTION
This is a follow-up to #2 and adds the license information to the NuGet package.

@dwmkerr When merged, could you kindly push a new package version of `DotNetWindowsRegistry` with #2 and this change to NuGet.org?

If you need further changes, like incrementing the package version as part of this PR please let me know and I will do it.